### PR TITLE
Add sad path to home page search bar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  # add_flash_types :danger, :info, :warning, :success
+  add_flash_types :danger, :info, :warning, :success
 
   def current_user
    @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,12 +1,16 @@
 class SearchController < ApplicationController
 
   def index
-    params[:q].present?
+    if not_in_denver?
+      redirect_to root_path, notice: "This demo currently only works for valid Denver zipcodes. Please enter a Denver zipcode. Sorry for the inconvience."
+    elsif valid
     @shelters = Shelter.near(params[:q], search_radius, :order => :distance)
+    else
+      redirect_to root_path, alert: "Please enter a valid 5 digit zipcode."
+    end
   end
 
 private
-
   def search_radius
     if params[:radius].present?
       params[:radius]
@@ -15,4 +19,15 @@ private
     end
   end
 
+  def valid
+    params[:q].present? && params[:q].length == 5 && params[:q].split("").all? {|i| (48..57).include?(i.ord)}
+  end
+
+
+  def not_in_denver?
+    denver_zipcodes = ["80012", "80014", "80022", "80033", "80123", "80127", "80202", "80203", "80204", "80205", "80206", "80207", "80209", "80210", "80211", "80212", "80214", "80215", "80216", "80218", "80219", "80220", "80221", "80222", "80223", "80224", "80225", "80226", "80227", "80228", "80229", "80230", "80231", "80232", "80233", "80234", "80235", "80236", "80237", "80238", "80239", "80241", "80246", "80247", "80249", "80260", "80264", "80265", "80266", "80290", "80293", "80294", "80299"]
+
+    in_denver = denver_zipcodes.include?(params[:q])
+    params[:q].length == 5 && params[:q].split("").all? {|i| (48..57).include?(i.ord)} && in_denver == false
+  end
 end


### PR DESCRIPTION
This pull request adds sad paths to the home page search bar. 
Currently displays error if input is not a valid zipcode (only 5 digits long and containing no letters).
If a zipcode that is not a Denver zip is entered a notice is also displayed to let  the user know that as a demo only Denver zipcodes are available at this time. 